### PR TITLE
Added number.Local in combination with facebook searches

### DIFF
--- a/scanners/google.go
+++ b/scanners/google.go
@@ -207,6 +207,8 @@ func getSocialMediaDorks(number *Number, formats ...string) (results []*GoogleSe
 			Or().
 			Intext(number.E164).
 			Or().
+			Intext(number.Local).
+			Or().
 			Intext(number.RawLocal),
 		(&dorkgen.GoogleSearch{}).
 			Site("twitter.com").


### PR DESCRIPTION
Facebook Pages (businesses, etc) in the US will not return any results with `RawLocal` formatting -- it requires `(000) 000-0000` Local formatting to get best results.